### PR TITLE
Feature: Dynamic protocol fee

### DIFF
--- a/src/UniversalBridgeProxy.sol
+++ b/src/UniversalBridgeProxy.sol
@@ -10,13 +10,7 @@ contract UniversalBridgeProxy {
     bytes32 private constant _ERC1967_IMPLEMENTATION_SLOT =
         0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
-    constructor(
-        address _implementation,
-        address _owner,
-        address _operator,
-        address payable _protocolFeeRecipient,
-        uint256 _protocolFeeBps
-    ) {
+    constructor(address _implementation, address _owner, address _operator, address payable _protocolFeeRecipient) {
         if (_implementation == address(0)) {
             revert ImplementationZeroAddress();
         }
@@ -34,11 +28,10 @@ contract UniversalBridgeProxy {
         }
 
         bytes memory data = abi.encodeWithSignature(
-            "initialize(address,address,address,uint256)",
+            "initialize(address,address,address)",
             _owner,
             _operator,
-            _protocolFeeRecipient,
-            _protocolFeeBps
+            _protocolFeeRecipient
         );
         (bool success, ) = _implementation.delegatecall(data);
 

--- a/src/UniversalBridgeV1.sol
+++ b/src/UniversalBridgeV1.sol
@@ -22,8 +22,6 @@ library UniversalBridgeStorage {
         mapping(bytes32 => bool) processed;
         /// @dev Mapping from forward address or token address => whether restricted.
         mapping(address => bool) isRestricted;
-        /// @dev protocol fee bps, capped at 300 bps (3%)
-        uint256 protocolFeeBps;
         /// @dev protocol fee recipient address
         address protocolFeeRecipient;
         /// @dev whether the bridge is paused
@@ -55,7 +53,7 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
         uint256 tokenAmount;
         address payable forwardAddress;
         address payable spenderAddress;
-        uint256 expirationTimestamp;
+        uint256 protocolFeeBps;
         address payable developerFeeRecipient;
         uint256 developerFeeBps;
         bytes callData;
@@ -64,7 +62,7 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
 
     bytes32 private constant TRANSACTION_REQUEST_TYPEHASH =
         keccak256(
-            "TransactionRequest(bytes32 transactionId,address tokenAddress,uint256 tokenAmount,address forwardAddress,address spenderAddress,uint256 expirationTimestamp,address developerFeeRecipient,uint256 developerFeeBps,bytes callData,bytes extraData)"
+            "TransactionRequest(bytes32 transactionId,address tokenAddress,uint256 tokenAmount,address forwardAddress,address spenderAddress,uint256 protocolFeeBps,address developerFeeRecipient,uint256 developerFeeBps,bytes callData,bytes extraData)"
         );
 
     /*///////////////////////////////////////////////////////////////
@@ -76,10 +74,10 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
         bytes32 indexed transactionId,
         address tokenAddress,
         uint256 tokenAmount,
+        uint256 protocolFee,
         address developerFeeRecipient,
         uint256 developerFeeBps,
         uint256 developerFee,
-        uint256 protocolFee,
         bytes extraData
     );
 
@@ -96,22 +94,16 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
     error UniversalBridgePaused(); // 0x46ecd2c9
     error UniversalBridgeRestrictedAddress(); // 0xec7d39b3
     error UniversalBridgeVerificationFailed(); // 0x1573f645
-    error UniversalBridgeRequestExpired(uint256 expirationTimestamp); // 0xb4ebecd8
     error UniversalBridgeTransactionAlreadyProcessed(); // 0x7d21ae4b
 
     constructor() {
         _disableInitializers();
     }
 
-    function initialize(
-        address _owner,
-        address _operator,
-        address payable _protocolFeeRecipient,
-        uint256 _protocolFeeBps
-    ) external initializer {
+    function initialize(address _owner, address _operator, address payable _protocolFeeRecipient) external initializer {
         _initializeOwner(_owner);
         _grantRoles(_operator, _OPERATOR_ROLE);
-        _setProtocolFeeInfo(_protocolFeeRecipient, _protocolFeeBps);
+        _setProtocolFeeInfo(_protocolFeeRecipient);
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -136,8 +128,8 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
         }
     }
 
-    function setProtocolFeeInfo(address payable feeRecipient, uint256 feeBps) external onlyOwner {
-        _setProtocolFeeInfo(feeRecipient, feeBps);
+    function setProtocolFeeInfo(address payable feeRecipient) external onlyOwner {
+        _setProtocolFeeInfo(feeRecipient);
     }
 
     function pause(bool _pause) external onlyOwner {
@@ -148,9 +140,8 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
         _universalBridgeStorage().isRestricted[_target] = _restrict;
     }
 
-    function getProtocolFeeInfo() external view returns (address feeRecipient, uint256 feeBps) {
+    function getProtocolFeeInfo() external view returns (address feeRecipient) {
         feeRecipient = _universalBridgeStorage().protocolFeeRecipient;
-        feeBps = _universalBridgeStorage().protocolFeeBps;
     }
 
     function isPaused() external view returns (bool) {
@@ -188,6 +179,10 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
             revert UniversalBridgeRestrictedAddress();
         }
 
+        if (req.protocolFeeBps > MAX_PROTOCOL_FEE_BPS) {
+            revert UniversalBridgeInvalidFeeBps();
+        }
+
         // verify amount
         if (req.tokenAmount == 0) {
             revert UniversalBridgeInvalidAmount(req.tokenAmount);
@@ -200,7 +195,8 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
             req.tokenAddress,
             req.tokenAmount,
             req.developerFeeRecipient,
-            req.developerFeeBps
+            req.developerFeeBps,
+            req.protocolFeeBps
         );
 
         if (_isNativeToken(req.tokenAddress)) {
@@ -251,10 +247,10 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
             req.transactionId,
             req.tokenAddress,
             req.tokenAmount,
+            protocolFee,
             req.developerFeeRecipient,
             req.developerFeeBps,
             developerFee,
-            protocolFee,
             req.extraData
         );
     }
@@ -282,10 +278,6 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
         TransactionRequest calldata req,
         bytes calldata signature
     ) private view returns (bool) {
-        if (req.expirationTimestamp < block.timestamp) {
-            revert UniversalBridgeRequestExpired(req.expirationTimestamp);
-        }
-
         bool processed = _universalBridgeStorage().processed[req.transactionId];
 
         if (processed) {
@@ -300,7 +292,7 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
                 req.tokenAmount,
                 req.forwardAddress,
                 req.spenderAddress,
-                req.expirationTimestamp,
+                req.protocolFeeBps,
                 req.developerFeeRecipient,
                 req.developerFeeBps,
                 keccak256(req.callData),
@@ -319,10 +311,10 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
         address tokenAddress,
         uint256 tokenAmount,
         address developerFeeRecipient,
-        uint256 developerFeeBps
+        uint256 developerFeeBps,
+        uint256 protocolFeeBps
     ) private returns (uint256, uint256) {
         address protocolFeeRecipient = _universalBridgeStorage().protocolFeeRecipient;
-        uint256 protocolFeeBps = _universalBridgeStorage().protocolFeeBps;
 
         uint256 protocolFee = (tokenAmount * protocolFeeBps) / 10_000;
         uint256 developerFee = (tokenAmount * developerFeeBps) / 10_000;
@@ -353,17 +345,12 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
         version = "1";
     }
 
-    function _setProtocolFeeInfo(address payable feeRecipient, uint256 feeBps) internal {
+    function _setProtocolFeeInfo(address payable feeRecipient) internal {
         if (feeRecipient == address(0)) {
             revert UniversalBridgeZeroAddress();
         }
 
-        if (feeBps > MAX_PROTOCOL_FEE_BPS) {
-            revert UniversalBridgeInvalidFeeBps();
-        }
-
         _universalBridgeStorage().protocolFeeRecipient = feeRecipient;
-        _universalBridgeStorage().protocolFeeBps = feeBps;
     }
 
     function _isNativeToken(address tokenAddress) private pure returns (bool) {
@@ -372,7 +359,7 @@ contract UniversalBridgeV1 is EIP712, Initializable, UUPSUpgradeable, OwnableRol
 
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
-    function _universalBridgeStorage() internal view returns (UniversalBridgeStorage.Data storage) {
+    function _universalBridgeStorage() internal pure returns (UniversalBridgeStorage.Data storage) {
         return UniversalBridgeStorage.data();
     }
 }

--- a/test/UniversalBridgeV1.t.sol
+++ b/test/UniversalBridgeV1.t.sol
@@ -20,10 +20,10 @@ contract UniversalBridgeTest is Test {
         bytes32 indexed transactionId,
         address tokenAddress,
         uint256 tokenAmount,
+        uint256 protocolFee,
         address developerFeeRecipient,
         uint256 developerFeeBps,
         uint256 developerFee,
-        uint256 protocolFee,
         bytes extraData
     );
 
@@ -73,9 +73,7 @@ contract UniversalBridgeTest is Test {
 
         // deploy impl and proxy
         address impl = address(new UniversalBridgeV1());
-        bridge = UniversalBridgeV1(
-            address(new UniversalBridgeProxy(impl, owner, operator, protocolFeeRecipient, protocolFeeBps))
-        );
+        bridge = UniversalBridgeV1(address(new UniversalBridgeProxy(impl, owner, operator, protocolFeeRecipient)));
 
         mockERC20 = new MockERC20("Token", "TKN");
         mockTarget = new MockTarget();
@@ -137,7 +135,7 @@ contract UniversalBridgeTest is Test {
                 req.tokenAmount,
                 req.forwardAddress,
                 req.spenderAddress,
-                req.expirationTimestamp,
+                req.protocolFeeBps,
                 req.developerFeeRecipient,
                 req.developerFeeBps,
                 keccak256(req.callData),
@@ -174,9 +172,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTarget));
         req.spenderAddress = payable(address(mockTarget));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature
@@ -218,9 +216,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTargetNonSpender));
         req.spenderAddress = payable(address(mockSpender));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature
@@ -260,9 +258,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(receiver));
         req.spenderAddress = payable(address(0));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -305,9 +303,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTarget));
         req.spenderAddress = payable(address(mockTarget));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature
@@ -351,9 +349,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTargetNonSpender));
         req.spenderAddress = payable(address(mockSpender));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature
@@ -391,9 +389,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(receiver));
         req.spenderAddress = payable(address(0));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature
@@ -435,9 +433,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTarget));
         req.spenderAddress = payable(address(mockTarget));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature
@@ -454,10 +452,10 @@ contract UniversalBridgeTest is Test {
             _transactionId,
             address(mockERC20),
             sendValue,
+            expectedProtocolFee,
             developer,
             developerFeeBps,
             expectedDeveloperFee,
-            expectedProtocolFee,
             ""
         );
         bridge.initiateTransaction(req, _signature);
@@ -471,7 +469,6 @@ contract UniversalBridgeTest is Test {
         req.transactionId = _transactionId;
         req.tokenAddress = address(mockERC20);
         req.tokenAmount = 0;
-        req.expirationTimestamp = 1000;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -497,9 +494,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(receiver));
         req.spenderAddress = payable(address(0));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature
@@ -530,9 +527,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(receiver));
         req.spenderAddress = payable(address(0));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = "";
 
         // generate signature
@@ -553,7 +550,6 @@ contract UniversalBridgeTest is Test {
         bytes32 _transactionId = keccak256("transaction ID");
 
         req.transactionId = _transactionId;
-        req.expirationTimestamp = 1000;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -576,7 +572,6 @@ contract UniversalBridgeTest is Test {
 
         req.transactionId = _transactionId;
         req.forwardAddress = payable(address(receiver));
-        req.expirationTimestamp = 1000;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -600,7 +595,6 @@ contract UniversalBridgeTest is Test {
         req.transactionId = _transactionId;
         req.tokenAddress = address(mockERC20);
         req.forwardAddress = payable(address(receiver));
-        req.expirationTimestamp = 1000;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -640,9 +634,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockRefundTarget));
         req.spenderAddress = payable(address(mockRefundTarget));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature
@@ -684,7 +678,6 @@ contract UniversalBridgeTest is Test {
         vm.prank(sender);
         mockERC20.approve(address(bridge), sendValueWithFees);
 
-
         // create transaction request
         UniversalBridgeV1.TransactionRequest memory req;
         bytes32 _transactionId = keccak256("erc20 refund transaction ID");
@@ -694,9 +687,9 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockRefundTarget));
         req.spenderAddress = payable(address(mockRefundTarget));
-        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
+        req.protocolFeeBps = protocolFeeBps;
         req.callData = targetCalldata;
 
         // generate signature

--- a/test/UniversalBridgeV1.t.sol
+++ b/test/UniversalBridgeV1.t.sol
@@ -87,7 +87,7 @@ contract UniversalBridgeTest is Test {
 
         // EIP712
         typehashTransactionRequest = keccak256(
-            "TransactionRequest(bytes32 transactionId,address tokenAddress,uint256 tokenAmount,address forwardAddress,address spenderAddress,uint256 expirationTimestamp,address developerFeeRecipient,uint256 developerFeeBps,bytes callData,bytes extraData)"
+            "TransactionRequest(bytes32 transactionId,address tokenAddress,uint256 tokenAmount,address forwardAddress,address spenderAddress,uint256 expirationTimestamp,uint256 protocolFeeBps,address developerFeeRecipient,uint256 developerFeeBps,bytes callData,bytes extraData)"
         );
         nameHash = keccak256(bytes("UniversalBridgeV1"));
         versionHash = keccak256(bytes("1"));
@@ -135,6 +135,7 @@ contract UniversalBridgeTest is Test {
                 req.tokenAmount,
                 req.forwardAddress,
                 req.spenderAddress,
+                req.expirationTimestamp,
                 req.protocolFeeBps,
                 req.developerFeeRecipient,
                 req.developerFeeBps,
@@ -172,6 +173,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTarget));
         req.spenderAddress = payable(address(mockTarget));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -216,6 +218,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTargetNonSpender));
         req.spenderAddress = payable(address(mockSpender));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -258,6 +261,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(receiver));
         req.spenderAddress = payable(address(0));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -303,6 +307,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTarget));
         req.spenderAddress = payable(address(mockTarget));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -349,6 +354,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTargetNonSpender));
         req.spenderAddress = payable(address(mockSpender));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -389,6 +395,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(receiver));
         req.spenderAddress = payable(address(0));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -433,6 +440,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockTarget));
         req.spenderAddress = payable(address(mockTarget));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -469,6 +477,7 @@ contract UniversalBridgeTest is Test {
         req.transactionId = _transactionId;
         req.tokenAddress = address(mockERC20);
         req.tokenAmount = 0;
+        req.expirationTimestamp = 1000;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -494,6 +503,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(receiver));
         req.spenderAddress = payable(address(0));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -527,6 +537,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(receiver));
         req.spenderAddress = payable(address(0));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -550,6 +561,7 @@ contract UniversalBridgeTest is Test {
         bytes32 _transactionId = keccak256("transaction ID");
 
         req.transactionId = _transactionId;
+        req.expirationTimestamp = 1000;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -572,6 +584,7 @@ contract UniversalBridgeTest is Test {
 
         req.transactionId = _transactionId;
         req.forwardAddress = payable(address(receiver));
+        req.expirationTimestamp = 1000;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -595,6 +608,7 @@ contract UniversalBridgeTest is Test {
         req.transactionId = _transactionId;
         req.tokenAddress = address(mockERC20);
         req.forwardAddress = payable(address(receiver));
+        req.expirationTimestamp = 1000;
 
         // generate signature
         bytes memory _signature = _prepareAndSignData(
@@ -634,6 +648,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockRefundTarget));
         req.spenderAddress = payable(address(mockRefundTarget));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;
@@ -687,6 +702,7 @@ contract UniversalBridgeTest is Test {
         req.tokenAmount = sendValue;
         req.forwardAddress = payable(address(mockRefundTarget));
         req.spenderAddress = payable(address(mockRefundTarget));
+        req.expirationTimestamp = 1000;
         req.developerFeeRecipient = developer;
         req.developerFeeBps = developerFeeBps;
         req.protocolFeeBps = protocolFeeBps;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Protocol fee can now be specified per transaction (protocolFeeBps in each request).
  - Transaction event now includes the computed protocolFee amount.

- Refactor
  - Removed global protocol-fee configuration; initialization no longer accepts a default fee BPS.
  - Request signing schema updated to include protocolFeeBps alongside expirationTimestamp.
  - Fee distribution and validation moved to per-request flow.

- Tests
  - Updated tests for per-request fees, updated event shape, and signing data.

- Bug Fixes
  - Deployment validation tightened to reject non-existent implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->